### PR TITLE
fix invalid inferred types for X,M; inferred type does not conform to declared bound(s) error in Java 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 *.iws
 target
+.idea/

--- a/sample/src/test/java/com/example/Expect.java
+++ b/sample/src/test/java/com/example/Expect.java
@@ -5,28 +5,31 @@ import com.pivotallabs.greatexpectations.matchers.*;
 import static com.pivotallabs.greatexpectations.GreatExpectations.wrapped;
 
 public class Expect {
-    public static <T extends Object, M extends ObjectMatcher<T, M>> ObjectMatcher<T, ?> expect(T actual) {
+    public static <T extends Object> ObjectMatcher<T, ?> expect(T actual) {
         return wrapped(ObjectMatcher.class, actual);
     }
     public static BooleanMatcher<Boolean, ?> expect(boolean actual) {
         return wrapped(BooleanMatcher.class, actual);
     }
-    public static <T extends Boolean, M extends BooleanMatcher<T, M>> BooleanMatcher<T, ?> expect(T actual) {
+    public static <T extends Boolean> BooleanMatcher<T, ?> expect(T actual) {
         return wrapped(BooleanMatcher.class, actual);
     }
-    public static <T extends Comparable, M extends ComparableMatcher<T, M>> ComparableMatcher<T, ?> expect(T actual) {
+    public static <T extends Comparable> ComparableMatcher<T, ?> expect(T actual) {
         return wrapped(ComparableMatcher.class, actual);
     }
-    public static <T extends java.util.Date, M extends DateMatcher<T, M>> DateMatcher<T, ?> expect(T actual) {
+    public static <T extends java.util.Date> DateMatcher<T, ?> expect(T actual) {
         return wrapped(DateMatcher.class, actual);
     }
-    public static <T extends Iterable<X>, X, M extends IterableMatcher<T, X, M>> IterableMatcher<T, X, ?> expect(T actual) {
+    public static <T extends Iterable<X>, X> IterableMatcher<T, X, ?> expect(T actual) {
         return wrapped(IterableMatcher.class, actual);
     }
-    public static <T extends Long, M extends LongMatcher<T, M>> LongMatcher<T, ?> expect(T actual) {
+    public static LongMatcher<Long, ?> expect(long actual) {
         return wrapped(LongMatcher.class, actual);
     }
-    public static <T extends String, M extends StringMatcher<T, M>> StringMatcher<T, ?> expect(T actual) {
+    public static <T extends Long> LongMatcher<T, ?> expect(T actual) {
+        return wrapped(LongMatcher.class, actual);
+    }
+    public static <T extends String> StringMatcher<T, ?> expect(T actual) {
         return wrapped(StringMatcher.class, actual);
     }
 }

--- a/src/main/java/com/pivotallabs/greatexpectations/Expect.java
+++ b/src/main/java/com/pivotallabs/greatexpectations/Expect.java
@@ -4,31 +4,31 @@ import com.pivotallabs.greatexpectations.matchers.*;
 import static com.pivotallabs.greatexpectations.GreatExpectations.wrapped;
 
 public class Expect {
-  public static <T extends Object, M extends ObjectMatcher<T, M>> ObjectMatcher<T, ?> expect(T actual) {
+  public static <T extends Object, M> ObjectMatcher<T, ?> expect(T actual) {
     return wrapped(ObjectMatcher.class, actual);
   }
   public static BooleanMatcher<Boolean, ?> expect(boolean actual) {
     return wrapped(BooleanMatcher.class, actual);
   }
-  public static <T extends Boolean, M extends BooleanMatcher<T, M>> BooleanMatcher<T, ?> expect(T actual) {
+  public static <T extends Boolean, M> BooleanMatcher<T, ?> expect(T actual) {
     return wrapped(BooleanMatcher.class, actual);
   }
-  public static <T extends Comparable, M extends ComparableMatcher<T, M>> ComparableMatcher<T, ?> expect(T actual) {
+  public static <T extends Comparable, M> ComparableMatcher<T, ?> expect(T actual) {
     return wrapped(ComparableMatcher.class, actual);
   }
-  public static <T extends java.util.Date, M extends DateMatcher<T, M>> DateMatcher<T, ?> expect(T actual) {
+  public static <T extends java.util.Date, M> DateMatcher<T, ?> expect(T actual) {
     return wrapped(DateMatcher.class, actual);
   }
-  public static <T extends Iterable<X>, X, M extends IterableMatcher<T, X, M>> IterableMatcher<T, X, ?> expect(T actual) {
+  public static <T extends Iterable<X>, X, M> IterableMatcher<T, X, ?> expect(T actual) {
     return wrapped(IterableMatcher.class, actual);
   }
-  public static <T extends java.util.Set<X>, X, M extends SetMatcher<T, X, M>> SetMatcher<T, X, ?> expect(T actual) {
+  public static <T extends java.util.Set<X>, X, M> SetMatcher<T, X, ?> expect(T actual) {
     return wrapped(SetMatcher.class, actual);
   }
-  public static <T extends Long, M extends LongMatcher<T, M>> LongMatcher<T, ?> expect(T actual) {
+  public static <T extends Long, M> LongMatcher<T, ?> expect(T actual) {
     return wrapped(LongMatcher.class, actual);
   }
-  public static <T extends String, M extends StringMatcher<T, M>> StringMatcher<T, ?> expect(T actual) {
+  public static <T extends String, M> StringMatcher<T, ?> expect(T actual) {
     return wrapped(StringMatcher.class, actual);
   }
 }

--- a/src/main/java/com/pivotallabs/greatexpectations/Expect.java
+++ b/src/main/java/com/pivotallabs/greatexpectations/Expect.java
@@ -4,31 +4,35 @@ import com.pivotallabs.greatexpectations.matchers.*;
 import static com.pivotallabs.greatexpectations.GreatExpectations.wrapped;
 
 public class Expect {
-  public static <T extends Object, M> ObjectMatcher<T, ?> expect(T actual) {
+  public static <T extends Object> ObjectMatcher<T, ?> expect(T actual) {
+    //noinspection unchecked
     return wrapped(ObjectMatcher.class, actual);
   }
   public static BooleanMatcher<Boolean, ?> expect(boolean actual) {
     return wrapped(BooleanMatcher.class, actual);
   }
-  public static <T extends Boolean, M> BooleanMatcher<T, ?> expect(T actual) {
+  public static <T extends Boolean> BooleanMatcher<T, ?> expect(T actual) {
     return wrapped(BooleanMatcher.class, actual);
   }
-  public static <T extends Comparable, M> ComparableMatcher<T, ?> expect(T actual) {
+  public static <T extends Comparable> ComparableMatcher<T, ?> expect(T actual) {
     return wrapped(ComparableMatcher.class, actual);
   }
-  public static <T extends java.util.Date, M> DateMatcher<T, ?> expect(T actual) {
+  public static <T extends java.util.Date> DateMatcher<T, ?> expect(T actual) {
     return wrapped(DateMatcher.class, actual);
   }
-  public static <T extends Iterable<X>, X, M> IterableMatcher<T, X, ?> expect(T actual) {
+  public static <T extends Iterable<X>, X> IterableMatcher<T, X, ?> expect(T actual) {
     return wrapped(IterableMatcher.class, actual);
   }
-  public static <T extends java.util.Set<X>, X, M> SetMatcher<T, X, ?> expect(T actual) {
+  public static <T extends java.util.Set<X>, X> SetMatcher<T, X, ?> expect(T actual) {
     return wrapped(SetMatcher.class, actual);
+  }
+  public static LongMatcher<Long, ?> expect(long actual) {
+    return wrapped(LongMatcher.class, actual);
   }
   public static <T extends Long, M> LongMatcher<T, ?> expect(T actual) {
     return wrapped(LongMatcher.class, actual);
   }
-  public static <T extends String, M> StringMatcher<T, ?> expect(T actual) {
+  public static <T extends String> StringMatcher<T, ?> expect(T actual) {
     return wrapped(StringMatcher.class, actual);
   }
 }

--- a/src/test/java/com/pivotallabs/greatexpectations/ExpectTest.java
+++ b/src/test/java/com/pivotallabs/greatexpectations/ExpectTest.java
@@ -1,0 +1,57 @@
+package com.pivotallabs.greatexpectations;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import org.junit.Test;
+
+public class ExpectTest {
+  @Test
+  public void testObjectMatcher() throws Exception {
+    Object nullObject = null;
+    Expect.expect(nullObject).toBeNull();
+  }
+
+  @Test
+  public void testBooleanMatcher_with_boolean() throws Exception {
+    Expect.expect(false).toBeFalse();
+  }
+
+  @Test
+  public void testBooleanMatcher_with_Object() throws Exception {
+    Expect.expect(Boolean.FALSE).toBeFalse();
+  }
+
+  @Test
+  public void testComparableMatcher() throws Exception {
+    Expect.expect(1).toBeGreaterThan(0);
+  }
+
+  @Test
+  public void testDateMatcher() throws Exception {
+    Expect.expect(new Date(20000)).toBeLaterThan(new Date(10000));
+  }
+
+  @Test
+  public void testIterableMatcher() throws Exception {
+    Expect.expect(Arrays.asList("a", "b", "c")).toContainExactly("a", "b", "c");
+  }
+
+  @Test
+  public void testSetMatcher() throws Exception {
+    HashSet<String> set = new HashSet<String>();
+    Collections.addAll(set, "a", "b", "c");
+    Expect.expect(set).toContain("b", "a", "c");
+  }
+
+  @Test
+  public void testLongMatcher() throws Exception {
+    Expect.expect(42L).toEqual(42);
+  }
+
+  @Test
+  public void testStringMatcher() throws Exception {
+    Expect.expect("abc").toMatch("b");
+  }
+}

--- a/src/test/java/com/pivotallabs/greatexpectations/ExpectTest.java
+++ b/src/test/java/com/pivotallabs/greatexpectations/ExpectTest.java
@@ -6,52 +6,70 @@ import java.util.Date;
 import java.util.HashSet;
 import org.junit.Test;
 
+import static com.pivotallabs.greatexpectations.Expect.expect;
+
 public class ExpectTest {
   @Test
   public void testObjectMatcher() throws Exception {
     Object nullObject = null;
-    Expect.expect(nullObject).toBeNull();
+    expect(nullObject).toBeNull();
+    expect(new Object()).not.toBeNull();
   }
 
   @Test
   public void testBooleanMatcher_with_boolean() throws Exception {
-    Expect.expect(false).toBeFalse();
+    expect(false).toBeFalse();
+    expect(false).not.toBeTrue();
   }
 
   @Test
   public void testBooleanMatcher_with_Object() throws Exception {
-    Expect.expect(Boolean.FALSE).toBeFalse();
+    expect(Boolean.FALSE).toBeFalse();
+    expect(Boolean.FALSE).not.toBeTrue();
   }
 
   @Test
   public void testComparableMatcher() throws Exception {
-    Expect.expect(1).toBeGreaterThan(0);
+    expect(1).toBeGreaterThan(0);
+    expect(1).not.toBeGreaterThan(2);
   }
 
   @Test
   public void testDateMatcher() throws Exception {
-    Expect.expect(new Date(20000)).toBeLaterThan(new Date(10000));
+    expect(new Date(20000)).toBeLaterThan(new Date(10000));
+    // TODO: This isn't working
+    //expect(new Date(20000)).not.toBeLaterThan(new Date(30000));
   }
 
   @Test
   public void testIterableMatcher() throws Exception {
-    Expect.expect(Arrays.asList("a", "b", "c")).toContainExactly("a", "b", "c");
+    expect(Arrays.asList("a", "b", "c")).toContainExactly("a", "b", "c");
+    expect(Arrays.asList("a", "b", "c")).not.toContainExactly("b", "c");
   }
 
   @Test
   public void testSetMatcher() throws Exception {
     HashSet<String> set = new HashSet<String>();
     Collections.addAll(set, "a", "b", "c");
-    Expect.expect(set).toContain("b", "a", "c");
+    expect(set).toContain("b", "a", "c");
+    expect(set).not.toContain("d", "e", "f");
   }
 
   @Test
-  public void testLongMatcher() throws Exception {
-    Expect.expect(42L).toEqual(42);
+  public void testLongMatcher_with_long() throws Exception {
+    expect(42L).toEqual(42);
+    expect(42L).not.toEqual(21);
+  }
+
+  @Test
+  public void testLongMatcher_with_Object() throws Exception {
+    expect(Long.valueOf(42L)).toEqual(42);
+    expect(Long.valueOf(42L)).not.toEqual(21);
   }
 
   @Test
   public void testStringMatcher() throws Exception {
-    Expect.expect("abc").toMatch("b");
+    expect("boo").toContain("oo");
+    expect("boo").not.toContain("boot");
   }
 }


### PR DESCRIPTION
This change adds tests around Expect and fixes the invalid inferred types error in Java 1.7
